### PR TITLE
Fixed dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ version: 2
 registries:
   maven-github:
     type: maven-repository
-    url: https://maven.pkg.github.com/hrv-mart
+    url: https://maven.pkg.github.com
     username: ${{secrets.OSSRH_USERNAME}}
     password: ${{secrets.OSSRH_TOKEN}}
 updates:


### PR DESCRIPTION
Now dependabot will able to check update for github maven repository.